### PR TITLE
fix: 회원가입 시 이메일 validation을 통과해야지만 이메일 전송 버튼을 누를 수 있도록 수정

### DIFF
--- a/src/widgets/signupEmail/emailForm/EmailForm.tsx
+++ b/src/widgets/signupEmail/emailForm/EmailForm.tsx
@@ -37,6 +37,8 @@ const EmailForm = ({ emailValue, emailValidate, authCodeValue, authCodeValidate,
     setIsConfirmEmail(false);
   }, [authCodeValue]);
 
+  console.log(errors.email);
+
   return (
     <S.Layout>
       <S.InputForm>
@@ -49,7 +51,7 @@ const EmailForm = ({ emailValue, emailValidate, authCodeValue, authCodeValidate,
           register={emailValidate}
           error={errors.email}
           onClick={() => sendEmail(emailValue)}
-          disabled={state.isOpen}
+          disabled={state.isOpen || isSendEmail || errors.email}
         />
         {isSendEmail && (
           <ConfirmInputContainer
@@ -62,7 +64,7 @@ const EmailForm = ({ emailValue, emailValidate, authCodeValue, authCodeValidate,
             error={errors.authCode}
             onClick={() => confirmEmail({ mail: emailValue, authCode: authCodeValue })}
             maxLength={6}
-            disabled={state.isOpen || isConfirmEmail}
+            disabled={state.isOpen || isConfirmEmail || errors.authCode}
           />
         )}
       </S.InputForm>


### PR DESCRIPTION
## 어떤 기능인가요?

회원가입 시 이메일 validation을 통과해야지만 이메일 전송 버튼을 누를 수 있도록 수정

## 작업 상세 내용

- [ ] TODO
- [ ] TODO
- [ ] TODO

## 테스트 방법 (선택)

> 리뷰어가 어떻게 볼 수 있나요?

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

> 리뷰어가 확인할 수 있는 캡처가 있다면 추가해 주세요.

## 고민되거나 어려운 부분 (선택)

> 이거 중점으로 봐주세요 👀
