### PR TITLE
fix: 회원가입 QA 진행

### DIFF
--- a/src/components/policy/policyModal/PolicyModal.tsx
+++ b/src/components/policy/policyModal/PolicyModal.tsx
@@ -3,6 +3,8 @@ import * as S from './policyModal.styled';
 import PolicyAccept from '../policyAccept/PolicyAccept';
 import isCheckWhite from '@/assets/isCheckWhite.svg';
 import checkbox from '@/assets/checkbox.svg';
+import { useAtom } from 'jotai';
+import { setAccepct } from '@/shared/store/atoms/policy';
 
 interface Props {
   isPolicyOpen: boolean;
@@ -16,6 +18,7 @@ const POLICY_LINK = {
 };
 
 const PolicyModal = ({ isPolicyOpen, setIsPolicyOpen }: Props) => {
+  const [, handleAcceptPolicy] = useAtom(setAccepct);
   const [acceptServicePolicy, setAcceptServicePolicy] = useState(false);
   const [acceptLocationPolicy, setAcceptLocationPolicy] = useState(false);
   const [acceptPrivacyPolicy, setAcceptPrivacyPolicy] = useState(false);
@@ -40,6 +43,9 @@ const PolicyModal = ({ isPolicyOpen, setIsPolicyOpen }: Props) => {
 
   const onClickPolicySaveBtn = () => {
     setIsPolicyOpen(false);
+    setTimeout(() => {
+      handleAcceptPolicy();
+    }, 500);
   };
 
   return (

--- a/src/mutation/auth/useSubmitSignup.ts
+++ b/src/mutation/auth/useSubmitSignup.ts
@@ -34,12 +34,12 @@ export const useSubmitSignup = () => {
 
         switch (status) {
           default:
-            alert('서버 점검중입니다. 잠시 후 다시 시도해주세요.');
+            alert('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
             navigate('/login?id=null&appointment=null');
             break;
         }
       }
-      alert('서버 점검중입니다. 잠시 후 다시 시도해주세요.');
+      alert('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
       navigate('/login?id=null&appointment=null');
     },
   });

--- a/src/pages/auth/emailSignup/EmailSignup.tsx
+++ b/src/pages/auth/emailSignup/EmailSignup.tsx
@@ -7,8 +7,10 @@ import AuthInfoForm from '@/widgets/signupEmail/authInfoForm/AuthInfoForm';
 import EmailForm from '@/widgets/signupEmail/emailForm/EmailForm';
 import NicknameForm from '@/widgets/signupEmail/nicknameForm/NicknameForm';
 import { useSubmitSignup } from '@/mutation/auth/useSubmitSignup';
+import { useNavigate } from 'react-router-dom';
 
 const EmailSignup = () => {
+  const navigate = useNavigate();
   const [step, setStep] = useState<'first' | 'second' | 'third'>('first');
   const {
     idValue,
@@ -34,9 +36,19 @@ const EmailSignup = () => {
     submitSignup({ loginId: idValue, email: emailValue, password: passwordValue, name: nicknameValue, nickname: nicknameValue, birth: '1996-09-17' });
   };
 
+  const handleBack = () => {
+    if (step === 'first') {
+      navigate(-1);
+    } else if (step === 'second') {
+      setStep('first');
+    } else if (step === 'third') {
+      setStep('second');
+    }
+  };
+
   return (
     <S.Layout>
-      <Header step={step} />
+      <Header step={step} handleBack={handleBack} />
       {step === 'first' && (
         <AuthInfoForm
           handleChangeStep={setStep}

--- a/src/pages/auth/emailSignup/emailSignup.styled.ts
+++ b/src/pages/auth/emailSignup/emailSignup.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Layout = styled.div`
-  padding: 75px 24px 38px;
+  padding: 75px 24px 0px;
   display: flex;
   flex-direction: column;
   height: 100vh;

--- a/src/shared/components/ConfirmInputContainer/ConfirmInputContainer.styled.ts
+++ b/src/shared/components/ConfirmInputContainer/ConfirmInputContainer.styled.ts
@@ -71,6 +71,7 @@ export const ErrCheck = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+  margin-top: -5px;
   font-size: 12px;
   color: var(--Sub-Color-danger, #f74747);
 `;

--- a/src/shared/components/InputContainer/InputContainer.styled.ts
+++ b/src/shared/components/InputContainer/InputContainer.styled.ts
@@ -50,6 +50,7 @@ export const ErrCheck = styled.div`
   display: flex;
   align-items: center;
   gap: 4px;
+  margin-top: -5px;
   color: var(--Sub-Color-danger, #f74747);
   font-size: 12px;
 `;

--- a/src/shared/store/atoms/policy.ts
+++ b/src/shared/store/atoms/policy.ts
@@ -1,0 +1,16 @@
+import { atom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+
+export const policyState = atomWithStorage('policyState', {
+  isAccept: false,
+});
+
+export const setAccepct = atom(null, (get, set) => {
+  const state = get(policyState);
+  set(policyState, { ...state, isAccept: true });
+});
+
+export const setNonAccepct = atom(null, (get, set) => {
+  const state = get(policyState);
+  set(policyState, { ...state, isAccept: false });
+});

--- a/src/widgets/signupEmail/authInfoForm/AuthInfoForm.tsx
+++ b/src/widgets/signupEmail/authInfoForm/AuthInfoForm.tsx
@@ -8,7 +8,7 @@ import ToastProvider from '@/shared/components/ToastProvider/ToastProvider';
 import { useExistLoginIdValidate } from '@/mutation/auth/useExistLoginIdValidate';
 import { useAtom } from 'jotai';
 import { toastState } from '@/shared/store/atoms/toast';
-import { policyState, setNonAccepct } from '@/shared/store/atoms/policy';
+import { policyState } from '@/shared/store/atoms/policy';
 
 interface Props {
   idValue: string;

--- a/src/widgets/signupEmail/authInfoForm/AuthInfoForm.tsx
+++ b/src/widgets/signupEmail/authInfoForm/AuthInfoForm.tsx
@@ -8,6 +8,7 @@ import ToastProvider from '@/shared/components/ToastProvider/ToastProvider';
 import { useExistLoginIdValidate } from '@/mutation/auth/useExistLoginIdValidate';
 import { useAtom } from 'jotai';
 import { toastState } from '@/shared/store/atoms/toast';
+import { policyState, setNonAccepct } from '@/shared/store/atoms/policy';
 
 interface Props {
   idValue: string;
@@ -22,15 +23,14 @@ interface Props {
 }
 
 const AuthInfoForm = ({ errors, passwordValue, passwordValidate, confirmPasswordValue, confirmPasswordValidate, idValue, idValidate, trigger, handleChangeStep }: Props) => {
-  // TODO: setIsValidId는 아이디 중복 확인이 통과하면 true로 변경
+  const [isPolicyAccept] = useAtom(policyState);
   const [isValidId, setIsValidId] = useState(false);
   const [isPolicyOpen, setIsPolicyOpen] = useState(true);
   const [state] = useAtom(toastState);
 
   const { mutate: isExistLoginId } = useExistLoginIdValidate(setIsValidId);
-
   const isValidInput = idValue && passwordValue && confirmPasswordValue && !errors.id && !errors.password && !errors.confirmPassword && isValidId;
-
+  console.log(isPolicyOpen);
   useEffect(() => {
     setIsValidId(false);
   }, [idValue]);
@@ -85,16 +85,16 @@ const AuthInfoForm = ({ errors, passwordValue, passwordValidate, confirmPassword
       <S.ToastConatiner>
         <ToastWrapper />
 
-        {!isPolicyOpen && (
+        {
           <S.BtnWrap>
             {isValidInput && <PrimaryShinBtn text="다음" onClick={() => handleChangeStep('second')} />}
             {!isValidInput && <S.NotActivateBtn disabled>다음</S.NotActivateBtn>}
           </S.BtnWrap>
-        )}
+        }
       </S.ToastConatiner>
 
       {/* 약관 동의 모달 */}
-      <PolicyModal isPolicyOpen={isPolicyOpen} setIsPolicyOpen={setIsPolicyOpen} />
+      {!isPolicyAccept.isAccept && <PolicyModal isPolicyOpen={isPolicyOpen} setIsPolicyOpen={setIsPolicyOpen} />}
     </S.Layout>
   );
 };

--- a/src/widgets/signupEmail/authInfoForm/authInfoForm.styled.ts
+++ b/src/widgets/signupEmail/authInfoForm/authInfoForm.styled.ts
@@ -10,6 +10,7 @@ export const Layout = styled.form`
 export const InputForm = styled.div`
   display: flex;
   flex-direction: column;
+  flex-grow: 1;
   gap: 20px;
 `;
 
@@ -72,7 +73,7 @@ export const Input = styled.input`
 `;
 
 export const BtnWrap = styled.div`
-  margin: 216px 0 36px;
+  margin: 216px 0px 38px;
   width: 100%;
 `;
 
@@ -82,11 +83,16 @@ export const NotActivateBtn = styled.button`
   border: 1px solid var(--System-Color-gray-500, #bac7da);
   background: var(--System-Color-gray-200, #eef1f6);
   padding: 25px 70px;
+  color: var(--Primary-Color-black, #000);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px; /* 150% */
+  letter-spacing: -0.6px;
 `;
 
 export const ToastWrap = styled.div`
-  position: absolute;
-  top: 100px;
+  position: fixed;
+  bottom: 134px;
 `;
 
 export const ToastConatiner = styled.div`

--- a/src/widgets/signupEmail/emailForm/emailForm.styled.ts
+++ b/src/widgets/signupEmail/emailForm/emailForm.styled.ts
@@ -82,6 +82,12 @@ export const NotActivateBtn = styled.button`
   border: 1px solid var(--System-Color-gray-500, #bac7da);
   background: var(--System-Color-gray-200, #eef1f6);
   padding: 25px 70px;
+
+  color: var(--Primary-Color-black, #000);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px; /* 150% */
+  letter-spacing: -0.6px;
 `;
 
 export const ToastConatiner = styled.div`
@@ -98,6 +104,6 @@ export const BtnWrap = styled.div`
 `;
 
 export const ToastWrap = styled.div`
-  position: absolute;
-  top: -120px;
+  position: fixed;
+  bottom: 134px;
 `;

--- a/src/widgets/signupEmail/header/Header.tsx
+++ b/src/widgets/signupEmail/header/Header.tsx
@@ -1,20 +1,18 @@
-import { useNavigate } from 'react-router-dom';
 import * as S from './header.styled';
 import chevronLeft from '@/assets/chevronLeft.svg';
 
 interface Props {
   step: 'first' | 'second' | 'third';
+  handleBack: () => void;
 }
 
-const Header = ({ step }: Props) => {
-  const navigate = useNavigate();
-
+const Header = ({ step, handleBack }: Props) => {
   return (
     <S.Header>
-      <S.Chevron_left_back onClick={() => navigate(-1)}>
+      <S.Chevron_left_back onClick={handleBack}>
         <img src={chevronLeft} alt="뒤로 가기" />
       </S.Chevron_left_back>
-      <S.Title>{step === 'third' ? '닉네임 설정' : '회원가입'}</S.Title>
+      <S.Title>{step === 'third' ? '닉네임 설정' : '회원 가입'}</S.Title>
     </S.Header>
   );
 };

--- a/src/widgets/signupEmail/nicknameForm/nicknameForm.styled.ts
+++ b/src/widgets/signupEmail/nicknameForm/nicknameForm.styled.ts
@@ -62,6 +62,12 @@ export const NotActivateBtn = styled.button`
   border: 1px solid var(--System-Color-gray-500, #bac7da);
   background: var(--System-Color-gray-200, #eef1f6);
   padding: 25px 70px;
+
+  color: var(--Primary-Color-black, #000);
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 24px; /* 150% */
+  letter-spacing: -0.6px;
 `;
 
 export const BtnWrap = styled.div`


### PR DESCRIPTION
## 어떤 기능인가요?

회원가입 QA 진행

## 작업 상세 내용

- [x] 회원가입 타이틀 띄어쓰기 → 회원 가입
- [x] 회원가입 페이지 '다음' 버튼 & 닉네임 설정 페이지 '저장' 버튼 비활성화-활성화 폰트 차이 → 비활성화 시 폰트 수정
- [x] 텍스트 필드-하단 체크 메시지 간격 더 좁게 수정 (와이어프레임 참고)
- [x] 토스트 위치 하향 조정 (와이어프레임 참고)
- [x] 닉네임 설정에서 이전 페이지 버튼 클릭 시 이전 플로우(이메일 인증)로 이동

## 테스트 방법 (선택)

> 리뷰어가 어떻게 볼 수 있나요?

## 캡처 혹은 관련 자료 (피그마 링크 등) (선택)

> 리뷰어가 확인할 수 있는 캡처가 있다면 추가해 주세요.

## 고민되거나 어려운 부분 (선택)

> 이거 중점으로 봐주세요 👀
